### PR TITLE
Update for Issue "Unable to cast UInt64 to DateTime at Azure.Messaging.ServiceBus.ServiceBusReceivedMessage.get_LockedUntil()" 

### DIFF
--- a/src/lib/broker/queue.ts
+++ b/src/lib/broker/queue.ts
@@ -616,8 +616,8 @@ export abstract class MessageSequence<M extends TaggedMessage> {
         }, lockDurationMs),
       })
 
-      message.message_annotations[Constants.lockedUntil] =
-        +new Date().getTime() + lockDurationMs
+      const locked_until = +Date.now() + lockDurationMs
+      message.message_annotations[Constants.lockedUntil] = new Date(locked_until)
 
       // TODO: set drained based on whether there are more messages to send
 


### PR DESCRIPTION
Hello, I am running into this same issue described by Issue #68 . I found it to be related to the attached pull request. Let me know if you find any issues.